### PR TITLE
Fix nuxt-link navegation between pages

### DIFF
--- a/components/menus/QiskitOrgMenu.vue
+++ b/components/menus/QiskitOrgMenu.vue
@@ -17,17 +17,17 @@
             <h2>Learn more</h2>
             <a class="vertical-navigation__item vertical-navigation__item--active" href="/">Community</a>
             <div class="vertical-community-navigation">
-              <a
+              <nuxt-link
                 v-for="(link, index) in links"
                 :key="index"
                 :class="{
                   'vertical-community-navigation__item': true,
                   'nuxt-link-active': isActive(link.to)
                 }"
-                :href="link.to"
+                :to="link.to"
               >
                 {{ link.label }}
-              </a>
+              </nuxt-link>
             </div>
             <a class="vertical-navigation__item" href="https://quantum-computing.ibm.com/jupyter/tutorial/1_start_here.ipynb" target="_blank">Tutorials</a>
             <a class="vertical-navigation__item" href="https://qiskit.org/documentation">API&nbsp;Documentation</a>
@@ -51,17 +51,17 @@
     <div class="community-menu menu-container menu-container--light">
       <section class="menu menu--framed">
         <nav class="navigation-group navigation-group--right-aligned navigation-group--fixed">
-          <a
+          <nuxt-link
             v-for="(link, index) in links"
             :key="index"
             :class="{
               'navigation-group__item': true,
               'nuxt-link-active': isActive(link.to)
             }"
-            :href="link.to"
+            :to="link.to"
           >
             {{ link.label }}
-          </a>
+          </nuxt-link>
         </nav>
       </section>
     </div>

--- a/plugins/deep-load.ts
+++ b/plugins/deep-load.ts
@@ -44,10 +44,12 @@ export default ({ app }) => {
       const sectionBasepath =
         typeof section.basepath !== 'undefined' ? section.basepath : basepath
 
-      section.collections[aCollection] =
-        await Promise.all(section.collections[aCollection].map(
-          path => import(`~/content/${sectionBasepath}${path}`)
-        ))
+      if (typeof section.collections[aCollection][0] === 'string') {
+        section.collections[aCollection] =
+          await Promise.all(section.collections[aCollection].map(
+            path => import(`~/content/${sectionBasepath}${path}`)
+          ))
+      }
     }
   }
 

--- a/plugins/deep-load.ts
+++ b/plugins/deep-load.ts
@@ -44,12 +44,10 @@ export default ({ app }) => {
       const sectionBasepath =
         typeof section.basepath !== 'undefined' ? section.basepath : basepath
 
-      if (typeof section.collections[aCollection][0] === 'string') {
-        section.collections[aCollection] =
-          await Promise.all(section.collections[aCollection].map(
-            path => import(`~/content/${sectionBasepath}${path}`)
-          ))
-      }
+      section.collections[aCollection] =
+        await Promise.all(section.collections[aCollection].map(
+          path => import(`~/content/${sectionBasepath}${path}`)
+        ))
     }
   }
 
@@ -61,16 +59,24 @@ export default ({ app }) => {
    * @param filePath the TOC file path inside the `~/contents/` folder.
    * @param options optional modifiers.
    */
+
+  const cache = {}
+
   async function deepLoadCardToc(
     filePath: string,
     options: DeepLoadOptions = { basePath: '' }
   ): Promise<any> {
     const { basePath } = options
-    const toc = await loadToc(`${basePath}${filePath}`)
-    for (const aSection of toc) {
-      await embedDocumentsInPlace(aSection, basePath)
+    const key = `${basePath}${filePath}`
+
+    if (!(key in cache)) {
+      const toc = await loadToc(key)
+      for (const aSection of toc) {
+        await embedDocumentsInPlace(aSection, basePath)
+      }
+      cache[key] = toc
     }
-    return toc
+    return cache[key]
   }
 
   app.deepLoadCardToc = deepLoadCardToc


### PR DESCRIPTION
Fixes qiskit/qiskit.org#243

Nuxt-link navegation was broken because function `deepLoadCardToc` is being executed in every page to load its content.

When this happens, there is a markdown import based on `section.collections[aCollection]`, which is an array of strings, that saves its content inside `section.collections[aCollection]` so it becomes into an array of objects.
The problem comes the user comes back to the same path and the import happens again but `section.collections[aCollection]` is no longer an array of strings but an array of objects instead.

That's why I added a condition for the import to only happen if `section.collections[aCollection]` is an array of strings.

Anyways, I still believe that the whole file needs a refactor in the future. The actual import is a bit too difficult.