### PR TITLE
Remove CTA and Application button

### DIFF
--- a/pages/advocates/index.vue
+++ b/pages/advocates/index.vue
@@ -54,8 +54,7 @@
         </ol>
         <ul class="actions">
           <li>
-            <Cta to="http://ibm.biz/qiskit-advocate">
-              Apply now
+              Closed
             </Cta>
           </li>
         </ul>


### PR DESCRIPTION
Remove CTA and Apply now for advocates application. Replace with 'Closed.'