### PR TITLE
[ISSUE-260] Responsive experiments

### DIFF
--- a/components/headers/ExperimentHeader.vue
+++ b/components/headers/ExperimentHeader.vue
@@ -122,22 +122,22 @@ export default class extends Vue {
 
 .experiment-header__media {
   width: 100%;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-gap: 0.5rem;
-
-  & > * {
-    max-width: 100%;
-
-    &:first-child {
-      grid-column-start: 1;
-      grid-column-end: 3;
-    }
-  }
 }
-@media (max-width: 600px) {
+
+@media (min-width: 600px) {
   .experiment-header__media {
-    display: block;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 0.5rem;
+
+    & > * {
+      max-width: 100%;
+
+      &:first-child {
+        grid-column-start: 1;
+        grid-column-end: 3;
+      }
+    }
   }
 }
 </style>

--- a/components/headers/ExperimentHeader.vue
+++ b/components/headers/ExperimentHeader.vue
@@ -135,4 +135,9 @@ export default class extends Vue {
     }
   }
 }
+@media (max-width: 600px) {
+  .experiment-header__media {
+    display: block;
+  }
+}
 </style>


### PR DESCRIPTION
Closes qiskit/qiskit.org#260

- [x] Fix responsive for experiments page
- [x] Check the rest of pages work fine

## Before:
![Captura de pantalla 2019-10-22 a las 13 51 54](https://user-images.githubusercontent.com/757942/67282996-29519500-f4d3-11e9-8a87-9d9ea150521c.png)

## After:
<img width="304" alt="Captura de pantalla 2019-10-24 a las 12 23 25" src="https://user-images.githubusercontent.com/8567677/67476738-e4576b00-f658-11e9-8bc4-c10f8651c63e.png">
