### PR TITLE
[ISSUE-270] Change all nuxt-links left

### DIFF
--- a/components/cards/ExperimentCard.vue
+++ b/components/cards/ExperimentCard.vue
@@ -1,7 +1,7 @@
 <template>
   <article class="experiment-card">
-    <a
-      :href="to"
+    <nuxt-link
+      :to="to"
       class="card-link"
     >
       <div
@@ -19,7 +19,7 @@
           {{ summary }}
         </p>
       </div>
-    </a>
+    </nuxt-link>
   </article>
 </template>
 

--- a/components/cards/ExperimentCarousel.vue
+++ b/components/cards/ExperimentCarousel.vue
@@ -25,10 +25,10 @@
       :key="`deck-experiment-${index}`"
       name="experiment-deck__slide"
     >
-      <a
+      <nuxt-link
         v-if="active == index"
         class="experiment-deck__slide slide-link"
-        :href="experiment.to"
+        :to="experiment.to"
       >
         <div
           class="experiment-deck__slide-picture"
@@ -45,7 +45,7 @@
             {{ experiment.description }}
           </p>
         </div>
-      </a>
+      </nuxt-link>
     </transition>
   </section>
 </template>

--- a/components/ctas/Cta.vue
+++ b/components/ctas/Cta.vue
@@ -1,7 +1,11 @@
 <template>
-  <a :class="{ button: true, 'button--secondary': secondary }" :href="to">
+  <component
+    :is="tag"
+    :class="{ button: true, 'button--secondary': secondary }"
+    :to="to"
+  >
     <slot />
-  </a>
+  </component>
 </template>
 
 <script lang="ts">
@@ -10,6 +14,7 @@ import { Component, Prop } from 'vue-property-decorator'
 
 @Component
 export default class extends Vue {
+  @Prop({ type: String, default: 'a' }) tag
   @Prop(String) to
   @Prop(Boolean) secondary
 

--- a/components/ctas/Cta.vue
+++ b/components/ctas/Cta.vue
@@ -1,8 +1,11 @@
 <template>
   <component
-    :is="tag"
-    :class="{ button: true, 'button--secondary': secondary }"
-    :to="to"
+    :is="isInternal(to) ? 'nuxt-link' : 'a'"
+    :class="[ 'button', { 'button--secondary': secondary } ]"
+    :href="to"
+    :to="isInternal(to) ? to : null"
+    :rel="isExternal(to) ? 'noopener' : null"
+    :target="isExternal(to) ? '_blank' : null"
   >
     <slot />
   </component>
@@ -14,7 +17,6 @@ import { Component, Prop } from 'vue-property-decorator'
 
 @Component
 export default class extends Vue {
-  @Prop({ type: String, default: 'a' }) tag
   @Prop(String) to
   @Prop(Boolean) secondary
 
@@ -22,12 +24,12 @@ export default class extends Vue {
     return url.startsWith('http')
   }
 
-  created() {
-    const targetUrl = this.$props.to
-    if (targetUrl && this.isExternal(targetUrl)) {
-      this.$attrs.target = '_blank'
-      this.$attrs.rel = 'noopener'
-    }
+  isMail(url: string): boolean {
+    return url.startsWith('mailto')
+  }
+
+  isInternal(url: string): boolean {
+    return !(this.isExternal(url) || this.isMail(url))
   }
 }
 </script>

--- a/components/footers/PageFooter.vue
+++ b/components/footers/PageFooter.vue
@@ -19,7 +19,7 @@
             Qiskit for Educators
           </h2>
           <ul>
-            <li><a class="footer-column__link" href="/textbook">Textbook</a></li>
+            <li><nuxt-link class="footer-column__link" to="/textbook">Textbook</nuxt-link></li>
             <li><a class="footer-column__link" href="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY" target="_blank" rel="noopener">Coding With Qiskit</a></li>
             <li><a class="footer-column__link" href="mailto:hello@qiskit.camp" target="_blank" rel="noopener">Host an Event</a></li>
           </ul>
@@ -27,13 +27,13 @@
             Qiskit Advocates
           </h2>
           <ul>
-            <li><a class="footer-column__link" href="/advocates#become-an-advocate">Become an Advocate</a></li>
+            <li><nuxt-link class="footer-column__link" to="/advocates#become-an-advocate">Become an Advocate</nuxt-link></li>
           </ul>
           <h2 class="footer-column__title">
             Qiskit Experiments
           </h2>
           <ul>
-            <li><a class="footer-column__link" href="/experiments#browse-the-experiments">Browse the experiments</a></li>
+            <li><nuxt-link class="footer-column__link" to="/experiments#browse-the-experiments">Browse the experiments</nuxt-link></li>
           </ul>
         </section>
         <section class="footer-column">

--- a/components/headers/ExperimentHeader.vue
+++ b/components/headers/ExperimentHeader.vue
@@ -22,14 +22,14 @@
       <Cta
         v-if="launch"
         class="experiment-header__cta"
-        :href="launch"
+        :to="launch"
       >
         Launch
       </Cta>
       <Cta
         v-if="source"
         class="experiment-header__cta"
-        :href="source"
+        :to="source"
         secondary
       >
         Explore the code

--- a/components/headers/ExperimentHeader.vue
+++ b/components/headers/ExperimentHeader.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="experiment-header-container">
     <div>
-      <a
+      <nuxt-link
         class="experiment-header__back-navigation"
-        href="/experiments"
+        to="/experiments"
       >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 18">
           <path fill="#999" d="M8.681.196l2.121 2.12-8.484 8.487-2.12-2.12z" />
@@ -14,7 +14,7 @@
           <path fill="#999" d="M10.803 15.047l-2.121 2.121L.197 8.683l2.121-2.121z" />
         </svg>
         Back to experiments
-      </a>
+      </nuxt-link>
       <h1>{{ name }}</h1>
       <p class="experiment-header__author">
         {{ authors }}

--- a/pages/advocates/index.vue
+++ b/pages/advocates/index.vue
@@ -88,7 +88,6 @@ import InnerNavigation from '~/components/menus/InnerNavigation.vue'
 import GatesHeader from '~/components/headers/GatesHeader.vue'
 import PageSection from '~/components/sections/PageSection.vue'
 import MapSection from '~/components/advocates/MapSection.vue'
-import Cta from '~/components/ctas/Cta.vue'
 import AdvocateCard from '~/components/cards/AdvocateCard.vue'
 import CompactFeature from '~/components/features/CompactFeature.vue'
 
@@ -98,7 +97,6 @@ import CompactFeature from '~/components/features/CompactFeature.vue'
     GatesHeader,
     PageSection,
     MapSection,
-    Cta,
     AdvocateCard,
     CompactFeature
   },

--- a/pages/education/index.vue
+++ b/pages/education/index.vue
@@ -38,7 +38,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta href="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY">
+            <Cta to="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY">
               View all episodes
             </Cta>
           </li>
@@ -65,7 +65,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta tag="nuxt-link" to="/textbook/">
+            <Cta to="/textbook/">
               Discover more
             </Cta>
           </li>
@@ -84,7 +84,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta href="mailto:hello@qiskit.camp">
+            <Cta to="mailto:hello@qiskit.camp">
               Request an event
             </Cta>
           </li>

--- a/pages/education/index.vue
+++ b/pages/education/index.vue
@@ -38,7 +38,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta to="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY">
+            <Cta href="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY">
               View all episodes
             </Cta>
           </li>
@@ -65,7 +65,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta to="/textbook/">
+            <Cta tag="nuxt-link" to="/textbook/">
               Discover more
             </Cta>
           </li>
@@ -84,7 +84,7 @@
         </p>
         <ul class="actions">
           <li>
-            <Cta to="mailto:hello@qiskit.camp">
+            <Cta href="mailto:hello@qiskit.camp">
               Request an event
             </Cta>
           </li>

--- a/pages/experiments/index.vue
+++ b/pages/experiments/index.vue
@@ -43,7 +43,7 @@ import { Component } from 'vue-property-decorator'
 import InnerNavigation from '~/components/menus/InnerNavigation.vue'
 import GatesHeader from '~/components/headers/GatesHeader.vue'
 import PageSection from '~/components/sections/PageSection.vue'
-import Cta from '~/components/ctas/Cta.vue'
+// import Cta from '~/components/ctas/Cta.vue'
 import ExperimentCard from '~/components/cards/ExperimentCard.vue'
 import ExperimentCarousel from '~/components/cards/ExperimentCarousel.vue'
 
@@ -52,7 +52,7 @@ import ExperimentCarousel from '~/components/cards/ExperimentCarousel.vue'
     InnerNavigation,
     GatesHeader,
     PageSection,
-    Cta,
+    // Cta,
     ExperimentCard,
     ExperimentCarousel
   },

--- a/pages/experiments/index.vue
+++ b/pages/experiments/index.vue
@@ -6,10 +6,6 @@
         main-title="Qiskit Experiments"
       >
         <p>Browse and contribute with innovatives ways of using quantum computing and Qiskit.</p>
-        <!--<p>Do you have something to share?</p>
-        <ul>
-          <Cta>Submit your experiment</Cta>
-        </ul>-->
       </GatesHeader>
     </header>
     <div class="inner-navigation-scope">
@@ -43,7 +39,6 @@ import { Component } from 'vue-property-decorator'
 import InnerNavigation from '~/components/menus/InnerNavigation.vue'
 import GatesHeader from '~/components/headers/GatesHeader.vue'
 import PageSection from '~/components/sections/PageSection.vue'
-// import Cta from '~/components/ctas/Cta.vue'
 import ExperimentCard from '~/components/cards/ExperimentCard.vue'
 import ExperimentCarousel from '~/components/cards/ExperimentCarousel.vue'
 
@@ -52,7 +47,6 @@ import ExperimentCarousel from '~/components/cards/ExperimentCarousel.vue'
     InnerNavigation,
     GatesHeader,
     PageSection,
-    // Cta,
     ExperimentCard,
     ExperimentCarousel
   },


### PR DESCRIPTION
Closes qiskit/qiskit.org#270

- [x] Replace all `nuxt-link`s left.

- [x] Refactor CTA component to support `nuxt-link` or `button` HTML tags using [dynamic components](https://vuejs.org/v2/guide/components.html#Dynamic-Components) with the `tag` prop.
The reason why `to` needs to be a prop is because nuxt-link need to have `to` inside the child component when it's created as a dynamic component as it's now otherwise `Cannot read property '_normalized'` error shows up. On the other hand, `href` can be called from the parent component that's why I deleted it in the child component (it was written as a prop before) since it was redundant.

- [x] Delete import of unused `Cta` components.