### PR TITLE
Sets the experiments description text color to black

### DIFF
--- a/pages/experiments/_experiment.vue
+++ b/pages/experiments/_experiment.vue
@@ -67,8 +67,9 @@ import MdContent from '~/components/MdContent.vue'
 export default class extends Vue { }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 #copy {
+  color: var(--body-color-dark);
   background-color: white;
   padding-top: 0;
   padding-bottom: 2rem;


### PR DESCRIPTION
Fixes [#371](https://github.com/Qiskit/qiskit.org/issues/317)

### Behavior
<img width="1064" alt="Screen Shot 2019-11-14 at 12 50 28" src="https://user-images.githubusercontent.com/17231966/68855132-e5bb0700-06dd-11ea-966f-6e42559b9eee.png">